### PR TITLE
Bugfix feature update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ qt_add_qml_module(regagram
         Utils/logger.h Utils/logger.cpp
         Utils/avatargenerator.h Utils/avatargenerator.cpp
         Network/networkmanager.h Network/networkmanager.cpp
+        Network/filenetworkmanager.h Network/filenetworkmanager.cpp
+        Network/messagenetworkmanager.h Network/messagenetworkmanager.cpp
         Managers/accountmanager.h Managers/accountmanager.cpp
         Managers/audiomanager.h Managers/audiomanager.cpp
         Managers/filemanager.h Managers/filemanager.cpp

--- a/Core/client.cpp
+++ b/Core/client.cpp
@@ -26,26 +26,26 @@ void Client::setupNetworkConnections() {
     connect(networkManager, &NetworkManager::connectionSuccess, this, &Client::connectionSuccess);
     connect(networkManager, &NetworkManager::connectionError, this, &Client::connectionError);
 
-    connect(networkManager, &NetworkManager::loginResultsReceived, accountManager, &AccountManager::processingLoginResultsFromServer);
-    connect(networkManager, &NetworkManager::registrationResultsReceived, accountManager, &AccountManager::processingRegistrationResultsFromServer);
-    connect(networkManager, &NetworkManager::messageReceived, messageHandler, &MessageHandler::processingPersonalMessage);
-    connect(networkManager, &NetworkManager::groupMessageReceived, messageHandler, &MessageHandler::processingGroupMessage);
-    connect(networkManager, &NetworkManager::searchDataReceived, accountManager, &AccountManager::processingSearchDataFromServer);
-    connect(networkManager, &NetworkManager::chatsUpdateDataReceived, messageHandler, &MessageHandler::updatingLatestMessagesFromServer);
-    connect(networkManager, &NetworkManager::loadMeassgesReceived, messageHandler, &MessageHandler::loadingNextMessages);
-    connect(networkManager, &NetworkManager::editResultsReceived, accountManager, &AccountManager::processingEditProfileFromServer);
-    connect(networkManager, &NetworkManager::avatarsUpdateReceived, accountManager, &AccountManager::processingAvatarsUpdateFromServer);
-    connect(networkManager, &NetworkManager::groupInfoReceived, accountManager, &AccountManager::processingGroupInfoSave);
-    connect(networkManager, &NetworkManager::dialogsInfoReceived, accountManager, &AccountManager::processingDialogsInfoSave);
-    connect(networkManager, &NetworkManager::deleteGroupMemberReceived, accountManager, &AccountManager::processingDeleteGroupMember);
-    connect(networkManager, &NetworkManager::addGroupMemberReceived, accountManager, &AccountManager::processingAddGroupMember);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::loginResultsReceived, accountManager, &AccountManager::processingLoginResultsFromServer);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::registrationResultsReceived, accountManager, &AccountManager::processingRegistrationResultsFromServer);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::messageReceived, messageHandler, &MessageHandler::processingPersonalMessage);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::groupMessageReceived, messageHandler, &MessageHandler::processingGroupMessage);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::searchDataReceived, accountManager, &AccountManager::processingSearchDataFromServer);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::chatsUpdateDataReceived, messageHandler, &MessageHandler::updatingLatestMessagesFromServer);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::loadMeassgesReceived, messageHandler, &MessageHandler::loadingNextMessages);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::editResultsReceived, accountManager, &AccountManager::processingEditProfileFromServer);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::avatarsUpdateReceived, accountManager, &AccountManager::processingAvatarsUpdateFromServer);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::groupInfoReceived, accountManager, &AccountManager::processingGroupInfoSave);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::dialogsInfoReceived, accountManager, &AccountManager::processingDialogsInfoSave);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::deleteGroupMemberReceived, accountManager, &AccountManager::processingDeleteGroupMember);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::addGroupMemberReceived, accountManager, &AccountManager::processingAddGroupMember);
 
-    connect(networkManager, &NetworkManager::removeAccountFromConfigManager, accountManager, &AccountManager::removeAccountFromConfigManager);
+    connect(networkManager->getMessageNetwork(), &MessageNetworkManager::removeAccountFromConfigManager, accountManager, &AccountManager::removeAccountFromConfigManager);
 }
 
 void Client::setupAccountConnections() {
     connect(accountManager, &AccountManager::loginSuccess, this, &Client::loginSuccess);
-    connect(accountManager, &AccountManager::loginSuccess,networkManager,&NetworkManager::connectToFileServer);
+    connect(accountManager, &AccountManager::loginSuccess,networkManager->getFileNetwork(),&FileNetworkManager::connectToFileServer);
     connect(accountManager, &AccountManager::loginFail, this, &Client::loginFail);
     connect(accountManager, &AccountManager::registrationSuccess, this, &Client::registrationSuccess);
     connect(accountManager, &AccountManager::registrationFail, this, &Client::registrationFail);
@@ -85,8 +85,8 @@ void Client::setupMessageConnections() {
     connect(this, &Client::requestMessageDownload, messageHandler, &MessageHandler::sendRequestMessagesLoading);
     connect(this, &Client::sendMessageWithFile, messageHandler, &MessageHandler::saveMessageAndSendFile);
 
-    connect(messageHandler, &MessageHandler::sendMessageJson, networkManager, &NetworkManager::sendData);
-    connect(messageHandler, &MessageHandler::sendFile, networkManager, &NetworkManager::sendFile);
+    connect(messageHandler, &MessageHandler::sendMessageJson, networkManager->getMessageNetwork(), &MessageNetworkManager::sendData);
+    connect(messageHandler, &MessageHandler::sendFile, networkManager->getFileNetwork(), &FileNetworkManager::sendFile);
     connect(messageHandler,&MessageHandler::checkAndSendAvatarUpdate,accountManager,&AccountManager::checkAndSendAvatarUpdate);
     connect(messageHandler,&MessageHandler::getContactList,accountManager,&AccountManager::getContactList);
     connect(messageHandler,&MessageHandler::getChatsInfo,accountManager,&AccountManager::getChatsInfo);
@@ -113,19 +113,19 @@ void Client::setupMessageConnections() {
 }
 
 void Client::setupFileConnections() {
-    connect(networkManager, &NetworkManager::sendMessageWithFile, messageHandler, &MessageHandler::sendMessageWithFile);
-    connect(networkManager, &NetworkManager::uploadFiles, fileManager, &FileManager::uploadFiles);
-    connect(networkManager, &NetworkManager::uploadVoiceFile, fileManager, &FileManager::uploadVoiceFile);
-    connect(networkManager, &NetworkManager::uploadAvatar, fileManager, &FileManager::uploadAvatar);
+    connect(networkManager->getFileNetwork(), &FileNetworkManager::sendMessageWithFile, messageHandler, &MessageHandler::sendMessageWithFile);
+    connect(networkManager->getFileNetwork(), &FileNetworkManager::uploadFiles, fileManager, &FileManager::uploadFiles);
+    connect(networkManager->getFileNetwork(), &FileNetworkManager::uploadVoiceFile, fileManager, &FileManager::uploadVoiceFile);
+    connect(networkManager->getFileNetwork(), &FileNetworkManager::uploadAvatar, fileManager, &FileManager::uploadAvatar);
 
     connect(this, &Client::getFile, fileManager, &FileManager::getFile);
-    connect(fileManager, &FileManager::sendToFileServer, networkManager, &NetworkManager::sendToFileServer);
-    connect(messageHandler, &MessageHandler::sendToFileServer, networkManager, &NetworkManager::sendToFileServer);
+    connect(fileManager, &FileManager::sendToFileServer, networkManager->getFileNetwork(), &FileNetworkManager::sendToFileServer);
+    connect(messageHandler, &MessageHandler::sendToFileServer, networkManager->getFileNetwork(), &FileNetworkManager::sendToFileServer);
 
     connect(messageHandler, &MessageHandler::sendAvatarsUpdate, accountManager, &AccountManager::sendAvatarsUpdate);
     connect(accountManager, &AccountManager::sendAvatarUrl, fileManager, &FileManager::sendAvatarUrl);
-    connect(networkManager, &NetworkManager::sendAvatarUrl, fileManager, &FileManager::sendAvatarUrl);
-    connect(this, &Client::sendNewAvatar, networkManager, &NetworkManager::sendAvatar);
+    connect(networkManager->getFileNetwork(), &FileNetworkManager::sendAvatarUrl, fileManager, &FileManager::sendAvatarUrl);
+    connect(this, &Client::sendNewAvatar, networkManager->getFileNetwork(), &FileNetworkManager::sendAvatar);
 }
 
 void Client::setupLoggingConnections() {

--- a/Core/client.cpp
+++ b/Core/client.cpp
@@ -45,6 +45,7 @@ void Client::setupNetworkConnections() {
 
 void Client::setupAccountConnections() {
     connect(accountManager, &AccountManager::loginSuccess, this, &Client::loginSuccess);
+    connect(accountManager, &AccountManager::loginSuccess,networkManager,&NetworkManager::connectToFileServer);
     connect(accountManager, &AccountManager::loginFail, this, &Client::loginFail);
     connect(accountManager, &AccountManager::registrationSuccess, this, &Client::registrationSuccess);
     connect(accountManager, &AccountManager::registrationFail, this, &Client::registrationFail);

--- a/Core/client.h
+++ b/Core/client.h
@@ -60,8 +60,8 @@ signals:
 
     void addAccount();
 
-    void sendMessage(const QString &message, const QString &receiver_login, const int &receiver_id, const QString &flag);
-    void sendMessageWithFile(const QString &message, const QString &receiver_login, const int &receiver_id, const QString& filePath, const QString &flag);
+    void sendMessage(const QString &message, const int &receiver_id, const QString &flag);
+    void sendMessageWithFile(const QString &message, const int &receiver_id, const QString& filePath, const QString &flag);
     void sendVoiceMessage(const QString &receiver_login, const int &receiver_id, const QString &flag);
     void sendSearchToServer(const QString &searchable);
     void sendLoginRequest(QString userlogin,QString password);

--- a/Managers/MessageManagers/messagehandler.h
+++ b/Managers/MessageManagers/messagehandler.h
@@ -57,8 +57,8 @@ signals:
 
     void updatingLatestMessagesFromServer(QJsonObject &latestMessages);
 
-    void sendMessage(const QString &message, const QString &receiver_login, const int &receiver_id, const QString &flag);
-    void saveMessageAndSendFile(const QString &message, const QString &receiver_login, const int &receiver_id,const QString& filePath, const QString &flag);
+    void sendMessage(const QString &message, const int &receiver_id, const QString &flag);
+    void saveMessageAndSendFile(const QString &message, const int &receiver_id,const QString& filePath, const QString &flag);
     void sendMessageWithFile(const QString &fileUrl,const QString &flag);
     void sendVoiceMessage(const QString &receiver_login, const int &receiver_id, const QString &flag);
 

--- a/Managers/MessageManagers/messagesender.cpp
+++ b/Managers/MessageManagers/messagesender.cpp
@@ -15,7 +15,7 @@ void MessageSender::setLogger(Logger *logger)
     this->logger = logger;
 }
 
-void MessageSender::sendMessage(const QString &message, const QString &receiver_login, const int &receiver_id, const QString &flag)
+void MessageSender::sendMessage(const QString &message, const int &receiver_id, const QString &flag)
 {
     QJsonObject personalMessageJson;
 
@@ -26,25 +26,21 @@ void MessageSender::sendMessage(const QString &message, const QString &receiver_
     personalMessageJson["sender_id"] = activeUserId;
 
     if(flag == "personal") {
-        personalMessageJson["receiver_login"] = receiver_login;
         personalMessageJson["receiver_id"] = receiver_id;
     } else if(flag == "group") {
-        personalMessageJson["group_name"] = receiver_login;
         personalMessageJson["group_id"] = receiver_id;
     }
 
     emit sendMessageJson(personalMessageJson);
 }
 
-void MessageSender::saveMessageAndSendFile(const QString &message, const QString &receiver_login, const int &receiver_id, const QString &filePath, const QString &flag)
+void MessageSender::saveMessageAndSendFile(const QString &message, const int &receiver_id, const QString &filePath, const QString &flag)
 {
     QJsonObject jsonMessage;
     jsonMessage["message"] = message;
     if(flag == "personal") {
-        jsonMessage["receiver_login"] = receiver_login;
         jsonMessage["receiver_id"] = receiver_id;
     } else if(flag == "group") {
-        jsonMessage["group_name"] = receiver_login;
         jsonMessage["group_id"] = receiver_id;
     }
 
@@ -88,14 +84,11 @@ void MessageSender::sendMessageWithFile(const QString &fileUrl, const QString &f
     messageJson["flag"] = flag + "_message";
     messageJson["message"] = jsonObject["message"].toString();
     messageJson["fileUrl"] = fileUrl;
-    messageJson["sender_login"] = activeUserLogin;
     messageJson["sender_id"] = activeUserId;
 
     if(flag == "personal") {
-        messageJson["receiver_login"] = jsonObject["receiver_login"].toString();;
         messageJson["receiver_id"] = jsonObject["receiver_id"].toInt();
     } else if(flag == "group") {
-        messageJson["group_name"] = jsonObject["group_name"].toString();;
         messageJson["group_id"] = jsonObject["group_id"].toInt();
     }
 

--- a/Managers/MessageManagers/messagesender.h
+++ b/Managers/MessageManagers/messagesender.h
@@ -21,8 +21,8 @@ public:
     void setLogger(Logger* logger);
 
 public slots:
-    void sendMessage(const QString &message, const QString &receiver_login, const int &receiver_id, const QString &flag);
-    void saveMessageAndSendFile(const QString &message, const QString &receiver_login, const int &receiver_id,const QString& filePath, const QString &flag);
+    void sendMessage(const QString &message, const int &receiver_id, const QString &flag);
+    void saveMessageAndSendFile(const QString &message, const int &receiver_id,const QString& filePath, const QString &flag);
     void sendMessageWithFile(const QString &fileUrl,const QString &flag);
     void sendVoiceMessage(const QString &receiver_login, const int &receiver_id, const QString &flag);
 

--- a/Managers/accountmanager.cpp
+++ b/Managers/accountmanager.cpp
@@ -342,6 +342,10 @@ void AccountManager::setupResponseHandler()
     connect(this,&AccountManager::processingDeleteGroupMember,&responseHandler,&ResponseHandler::processingDeleteGroupMember);
     connect(this,&AccountManager::processingAddGroupMember,&responseHandler,&ResponseHandler::processingAddGroupMember);
 
+    connect(&responseHandler,&ResponseHandler::sendData, [this](const QJsonObject& json) {
+        networkManager->getMessageNetwork()->sendData(json);
+    });
+
     connect(&responseHandler,&ResponseHandler::transferUserNameAndIdAfterLogin,this,&AccountManager::transferUserNameAndIdAfterLogin);
     connect(&responseHandler,&ResponseHandler::checkAndSendAvatarUpdate,this,&AccountManager::checkAndSendAvatarUpdate);
     connect(&responseHandler,&ResponseHandler::loginSuccess,this,&AccountManager::loginSuccess);

--- a/Managers/accountmanager.cpp
+++ b/Managers/accountmanager.cpp
@@ -22,7 +22,7 @@ void AccountManager::logout()
 {
     QJsonObject json;
     json["flag"]= "logout";
-    networkManager->sendData(json);
+    networkManager->getMessageNetwork()->sendData(json);
     logger->log(Logger::INFO,"accountmanager.cpp::logout","Client logout process has begun");
     configManager.removeAccount(configManager.getActiveAccount());
 }
@@ -32,7 +32,7 @@ void AccountManager::sendSearchToServer(const QString &searchable)
     QJsonObject dataForSearchUsers;
     dataForSearchUsers["flag"] = "search";
     dataForSearchUsers["searchable"] = searchable;
-    networkManager->sendData(dataForSearchUsers);
+    networkManager->getMessageNetwork()->sendData(dataForSearchUsers);
 }
 
 void AccountManager::sendEditProfileRequest(const QString editable, const QString editInformation)
@@ -42,14 +42,14 @@ void AccountManager::sendEditProfileRequest(const QString editable, const QStrin
     dataEditProfile["user_id"] = activeUserId;
     dataEditProfile["editable"] = editable;
     dataEditProfile["editInformation"] = editInformation;
-    networkManager->sendData(dataEditProfile);
+    networkManager->getMessageNetwork()->sendData(dataEditProfile);
 }
 
 void AccountManager::clientChangeAccount()
 {
     QJsonObject json;
     json["flag"]= "logout";
-    networkManager->sendData(json);
+    networkManager->getMessageNetwork()->sendData(json);
 }
 
 void AccountManager::checkAndSendAvatarUpdate(const QString &avatar_url, const int &user_id,const QString& type)
@@ -68,7 +68,7 @@ void AccountManager::sendAvatarsUpdate()
     QJsonObject avatarsUpdateJson;
     avatarsUpdateJson["flag"] = "avatars_update";
     avatarsUpdateJson["user_id"] = activeUserId;
-    networkManager->sendData(avatarsUpdateJson);
+    networkManager->getMessageNetwork()->sendData(avatarsUpdateJson);
 }
 
 void AccountManager::setActiveUser(const QString &user_login, const int &user_id)
@@ -95,7 +95,7 @@ void AccountManager::createGroup(const QString &groupName, const QString& avatar
 
     if(avatarPath == ""){
         createGroupJson["avatar_url"] = "";
-        networkManager->sendData(createGroupJson);
+        networkManager->getMessageNetwork()->sendData(createGroupJson);
     } else {
         QFile file(avatarPath);
         QFileInfo fileInfo(avatarPath);
@@ -108,7 +108,7 @@ void AccountManager::createGroup(const QString &groupName, const QString& avatar
         createGroupJson["fileExtension"] = fileInfo.suffix();
         createGroupJson["fileData"] = QString(fileData.toBase64());
         QJsonDocument doc(createGroupJson);
-        networkManager->sendToFileServer(doc);
+        networkManager->getFileNetwork()->sendToFileServer(doc);
     }
 }
 
@@ -119,7 +119,7 @@ void AccountManager::addGroupMembers(const int &group_id, const QVariantList &se
     addMembersJson["group_id"] = group_id;
     addMembersJson["admin_id"] = this->activeUserId;
     addMembersJson["members"] = convertContactsToArray(selectedContacts);
-    networkManager->sendData(addMembersJson);
+    networkManager->getMessageNetwork()->sendData(addMembersJson);
 }
 
 void AccountManager::getGroupMembers(const int &group_id)
@@ -154,7 +154,7 @@ void AccountManager::deleteMemberFromGroup(const int &user_id, const int &group_
     deleteMemberObject["creator_id"] = this->activeUserId;
 
     if(user_id != this->activeUserId){
-        networkManager->sendData(deleteMemberObject);
+        networkManager->getMessageNetwork()->sendData(deleteMemberObject);
     }
 }
 
@@ -250,7 +250,7 @@ void AccountManager::getChatsInfo()
     QJsonObject infoObject;
     infoObject["flag"] = "chats_info";
     infoObject["user_id"] = activeUserId;
-    networkManager->sendData(infoObject);
+    networkManager->getMessageNetwork()->sendData(infoObject);
 }
 
 bool AccountManager::isAvatarUpToDate(QString avatar_url, int user_id,const QString& type)
@@ -297,7 +297,7 @@ void AccountManager::sendAuthRequest(const QString &flag, const QString &login, 
     data["flag"] = flag;
     data["login"] = login;
     data["password"] = password;
-    networkManager->sendData(data);
+    networkManager->getMessageNetwork()->sendData(data);
 }
 
 QJsonArray AccountManager::convertContactsToArray(const QVariantList &contacts)
@@ -371,5 +371,5 @@ void AccountManager::updatingChats()
     QJsonObject mainObject;
     mainObject["flag"] = "updating_chats";
     mainObject["user_id"] = activeUserId;
-    networkManager->sendData(mainObject);
+    networkManager->getMessageNetwork()->sendData(mainObject);
 }

--- a/Managers/accountmanager.cpp
+++ b/Managers/accountmanager.cpp
@@ -67,29 +67,7 @@ void AccountManager::sendAvatarsUpdate()
 
     QJsonObject avatarsUpdateJson;
     avatarsUpdateJson["flag"] = "avatars_update";
-
-    auto collectIdsFromDir = [](const QString& dirPath) {
-        QJsonArray ids;
-        QDir dir(dirPath);
-        if (dir.exists()) {
-            QStringList filters;
-            filters << "*.json";
-            for (const QFileInfo& fileInfo : dir.entryInfoList(filters, QDir::Files)) {
-                bool ok;
-                int id = fileInfo.baseName().toInt(&ok);
-                if (ok) ids.append(id);
-            }
-        }
-        return ids;
-    };
-
-    QString dialogsInfoDirPath = appDir + "/.data/" + QString::number(activeUserId) + "/dialogsInfo";
-    avatarsUpdateJson["ids"] = collectIdsFromDir(dialogsInfoDirPath);
-
-
-    QString groupInfoDirPath = appDir + "/.data/" + QString::number(activeUserId) + "/groupsInfo";
-    avatarsUpdateJson["groups_ids"] = collectIdsFromDir(groupInfoDirPath);
-
+    avatarsUpdateJson["user_id"] = activeUserId;
     networkManager->sendData(avatarsUpdateJson);
 }
 

--- a/Managers/responsehandler.cpp
+++ b/Managers/responsehandler.cpp
@@ -27,6 +27,10 @@ void ResponseHandler::processingLoginResults(const QJsonObject &loginResultsJson
 
     if(success == "ok")
     {
+        QJsonObject setIdentifiers;
+        setIdentifiers["flag"] = "identifiers";
+        setIdentifiers["user_id"] = userId;
+        emit sendData(setIdentifiers);
         emit transferUserNameAndIdAfterLogin(userlogin,userId);
         emit loginSuccess(userlogin, userId);
         emit checkAndSendAvatarUpdate(avatar_url, userId, "personal");

--- a/Managers/responsehandler.cpp
+++ b/Managers/responsehandler.cpp
@@ -28,8 +28,8 @@ void ResponseHandler::processingLoginResults(const QJsonObject &loginResultsJson
     if(success == "ok")
     {
         emit transferUserNameAndIdAfterLogin(userlogin,userId);
-        emit checkAndSendAvatarUpdate(avatar_url, userId, "personal");
         emit loginSuccess(userlogin, userId);
+        emit checkAndSendAvatarUpdate(avatar_url, userId, "personal");
         emit addAccount(userlogin,password,userId);
         emit updatingChats();
     }

--- a/Managers/responsehandler.cpp
+++ b/Managers/responsehandler.cpp
@@ -19,7 +19,7 @@ void ResponseHandler::processingLoginResults(const QJsonObject &loginResultsJson
 {
     logger->log(Logger::INFO,"responsehandler.cpp::processingLoginResults","processingLoginResults has begun");
     QString success = loginResultsJson["success"].toString();
-    QString name = loginResultsJson["name"].toString();
+    QString userlogin = loginResultsJson["userlogin"].toString();
     QString password = loginResultsJson["password"].toString();
     int userId = loginResultsJson["user_id"].toInt();
 
@@ -27,10 +27,10 @@ void ResponseHandler::processingLoginResults(const QJsonObject &loginResultsJson
 
     if(success == "ok")
     {
-        emit transferUserNameAndIdAfterLogin(name,userId);
+        emit transferUserNameAndIdAfterLogin(userlogin,userId);
         emit checkAndSendAvatarUpdate(avatar_url, userId, "personal");
-        emit loginSuccess(name, userId);
-        emit addAccount(name,password,userId);
+        emit loginSuccess(userlogin, userId);
+        emit addAccount(userlogin,password,userId);
         emit updatingChats();
     }
     else if(success == "poor")

--- a/Managers/responsehandler.h
+++ b/Managers/responsehandler.h
@@ -39,6 +39,8 @@ signals:
     void addAccount(const QString &login, const QString &password, int userId);
     void updatingChats();
 
+    void sendData(const QJsonObject& json);
+
     void registrationSuccess();
     void registrationFail(QString error);
 

--- a/Network/filenetworkmanager.cpp
+++ b/Network/filenetworkmanager.cpp
@@ -1,0 +1,263 @@
+#include "filenetworkmanager.h"
+
+FileNetworkManager::FileNetworkManager(QObject *parent)
+    : QObject{parent}
+{
+    fileSocket = new QTcpSocket(this);
+
+    activeUserId = 0;
+    activeUserLogin = "";
+
+    QObject::connect(fileSocket, &QTcpSocket::connected, [this]() {
+        logger->log(Logger::INFO,"filenetworkmanager.cpp::constructor","Connection to the FileServer established");
+        QJsonObject setIdentifiers;
+        setIdentifiers["flag"] = "identifiers";
+        setIdentifiers["userlogin"] = activeUserLogin;
+        setIdentifiers["user_id"] = activeUserId;
+        sendToFileServer(QJsonDocument(setIdentifiers));
+
+        {
+            QMutexLocker lock(&fileMutex);
+            if (!sendFileQueue.isEmpty()) {
+                QMetaObject::invokeMethod(this, "processSendFileQueue", Qt::QueuedConnection);
+            }
+        }
+    });
+    connect(fileSocket,&QTcpSocket::readyRead,this,&FileNetworkManager::onFileServerReceived);
+    connect(fileSocket,&QTcpSocket::disconnected,this,&FileNetworkManager::onDisconnected);
+    connect(fileSocket,&QTcpSocket::bytesWritten,this,&FileNetworkManager::handleFileBytesWritten);
+    connect(fileSocket, &QAbstractSocket::errorOccurred, [this](QAbstractSocket::SocketError socketError) {
+        emit onDisconnected();
+        logger->log(Logger::ERROR,"filenetworkmanager.cpp::constructor","Connection to the FileServer error: " + fileSocket->errorString());
+    });
+}
+
+QAbstractSocket::SocketState FileNetworkManager::getSocketState() const
+{
+    return fileSocket->state();
+}
+
+void FileNetworkManager::connectToFileServer()
+{
+    QFile file("ip.txt");
+    if (!file.exists() || file.size() == 0) {
+        file.open(QIODevice::WriteOnly | QIODevice::Text);
+        file.write("127.0.0.1\n");
+        file.close();
+    }
+    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    QString ip = QString::fromUtf8(file.readLine()).trimmed();
+    file.close();
+    fileSocket->connectToHost(ip,2021);
+}
+
+void FileNetworkManager::sendToFileServer(const QJsonDocument &doc)
+{
+    logger->log(Logger::INFO,"filenetworkmanager.cpp::sendToFileServer","sendToFileServer starts");
+    QByteArray fileDataOut = doc.toJson(QJsonDocument::Compact);
+
+    bool shouldStartProcessing = false;
+    {
+        QMutexLocker lock(&fileMutex);
+        if (sendFileQueue.size() >= MAX_QUEUE_SIZE) {
+            logger->log(Logger::DEBUG, "filenetworkmanager.cpp::sendToFileServer", "Send queue overflow! Dropping message.");
+            return;
+        }
+        sendFileQueue.enqueue(fileDataOut);
+        logger->log(Logger::INFO, "filenetworkmanager.cpp::sendToFileServer", "Message added to queue. Queue size: " + QString::number(sendFileQueue.size()));
+        shouldStartProcessing = sendFileQueue.size() == 1;
+    }
+
+    if (shouldStartProcessing) {
+        logger->log(Logger::INFO, "filenetworkmanager.cpp::sendToFileServer", "Starting to process the send queue.");
+        processSendFileQueue();
+    }
+}
+
+void FileNetworkManager::sendFile(const QString &filePath,const QString &flag)
+{
+    logger->log(Logger::INFO,"filenetworkmanager.cpp::sendFile","Sending file");
+    logger->log(Logger::INFO,"filenetworkmanager.cpp::sendFile","filePath = " + filePath);
+    QFile file(filePath);
+    QFileInfo fileInfo(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        logger->log(Logger::WARN,"filenetworkmanager.cpp::sendFile","Failed open file");
+    }
+
+    QByteArray fileData = file.readAll();
+    file.close();
+
+    QJsonObject fileDataJson;
+    fileDataJson["flag"] = flag;
+    fileDataJson["fileName"] = fileInfo.baseName();
+    fileDataJson["fileExtension"] = fileInfo.suffix();
+    fileDataJson["fileData"] = QString(fileData.toBase64());
+
+    QJsonDocument doc(fileDataJson);
+    sendToFileServer(doc);
+}
+
+void FileNetworkManager::sendAvatar(const QString &avatarPath, const QString &type, const int& id)
+{
+    logger->log(Logger::INFO,"filenetworkmanager.cpp::sendAvatar","Sending avatar");
+    QFile file(avatarPath);
+    QFileInfo fileInfo(avatarPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        logger->log(Logger::WARN,"filenetworkmanager.cpp::sendAvatar","Failed open avatar");
+    }
+
+    QByteArray fileData = file.readAll();
+    file.close();
+
+    QJsonObject fileDataJson;
+    fileDataJson["flag"] = "newAvatarData";
+    fileDataJson["type"] = type;
+    fileDataJson["id"] = id;
+    fileDataJson["fileName"] = fileInfo.baseName();
+    fileDataJson["fileExtension"] = fileInfo.suffix();
+    fileDataJson["fileData"] = QString(fileData.toBase64());
+
+    QJsonDocument doc(fileDataJson);
+    sendToFileServer(doc);
+}
+
+void FileNetworkManager::setActiveUser(const QString &userName, const int &userId)
+{
+    activeUserId = userId;
+    activeUserLogin = userName;
+}
+
+void FileNetworkManager::setLogger(Logger *logger)
+{
+    this->logger = logger;
+}
+
+void FileNetworkManager::onFileServerReceived()
+{
+    QDataStream in(fileSocket);
+    logger->log(Logger::INFO,"filenetworkmanager.cpp::onFileServerReceived","Data from FileServer received");
+    in.setVersion(QDataStream::Qt_6_7);
+
+    static quint32 blockSize = 0;
+
+    if(in.status() != QDataStream::Ok) {
+        logger->log(Logger::ERROR, "filenetworkmanager.cpp::onFileServerReceived", "Error reading data from socket: " + QString::number(in.status()));
+        return;
+    }
+
+    while (true) {
+        if (blockSize == 0) {
+            if (fileSocket->bytesAvailable() < sizeof(quint32))
+                return;
+            in >> blockSize;
+        }
+
+        if (fileSocket->bytesAvailable() < blockSize)
+            return;
+
+        QByteArray jsonData;
+        jsonData.resize(blockSize);
+        in.readRawData(jsonData.data(), blockSize);
+
+        QJsonDocument doc = QJsonDocument::fromJson(jsonData);
+
+        if (doc.isNull()) {
+            logger->log(Logger::ERROR,"filenetworkmanager.cpp::onFileServerReceived","Received JSON doc is null");
+            blockSize = 0;
+            return;
+        }
+
+        QJsonObject receivedFromServerJson = doc.object();
+        QString flag = receivedFromServerJson["flag"].toString();
+        logger->log(Logger::INFO, "filenetworkmanager.cpp::onFileServerReceived", "Readings JSON for " + flag);
+
+        auto it = flagMap.find(flag.toStdString());
+        uint flagId = (it != flagMap.end()) ? it->second : 0;
+
+        switch (flagId) {
+        case 1: {
+            QString fileUrl = receivedFromServerJson["fileUrl"].toString();
+            emit sendMessageWithFile(fileUrl, "personal");
+            break;
+        }
+        case 2: {
+            QString fileUrl = receivedFromServerJson["fileUrl"].toString();
+            emit sendMessageWithFile(fileUrl, "group");
+            break;
+        }
+        case 3:
+            emit uploadFiles(receivedFromServerJson);
+            break;
+        case 4:
+            emit uploadAvatar(receivedFromServerJson);
+            break;
+        case 5: {
+            emit sendAvatarUrl(
+                receivedFromServerJson["avatar_url"].toString(),
+                receivedFromServerJson["id"].toInt(),
+                receivedFromServerJson["type"].toString()
+                );
+            break;
+        }
+        case 6:
+            emit uploadVoiceFile(receivedFromServerJson);
+            break;
+        default:
+            logger->log(Logger::WARN, "filenetworkmanager.cpp::onFileServerReceived", "Unknown file flag received: " + flag);
+            break;
+        }
+        blockSize = 0;
+    }
+    logger->log(Logger::INFO,"filenetworkmanager.cpp::onFileServerReceived","Leave onDataReceived");
+}
+
+void FileNetworkManager::handleFileBytesWritten(qint64 bytes)
+{
+    QMutexLocker lock(&fileMutex);
+
+    logger->log(Logger::INFO, "filenetworkmanager.cpp::handleFileBytesWritten", "Bytes written: " + QString::number(bytes));
+
+    if (!sendFileQueue.isEmpty()) {
+        sendFileQueue.dequeue();
+        logger->log(Logger::INFO, "filenetworkmanager.cpp::handleFileBytesWritten", "Message dequeued. Queue size: " + QString::number(sendFileQueue.size()));
+        if (!sendFileQueue.isEmpty()) {
+            logger->log(Logger::INFO, "filenetworkmanager.cpp::handleFileBytesWritten", "More messages in queue. Scheduling next processing.");
+            QTimer::singleShot(10, this, &FileNetworkManager::processSendFileQueue);
+        }
+    }
+}
+
+void FileNetworkManager::processSendFileQueue()
+{
+    QMutexLocker lock(&fileMutex);
+    if (sendFileQueue.isEmpty()) {
+        logger->log(Logger::DEBUG, "filenetworkmanager.cpp::processSendFileQueue", "Send file queue is empty. Nothing to process.");
+        return;
+    }
+
+    QByteArray jsonData = sendFileQueue.head();
+    QByteArray bytes;
+    QDataStream out(&bytes, QIODevice::WriteOnly);
+    out.setVersion(QDataStream::Qt_6_7);
+
+    out << quint32(jsonData.size());
+    out.writeRawData(jsonData.data(), jsonData.size());
+    logger->log(Logger::INFO, "filenetworkmanager.cpp::processSendFileQueue", "Preparing to send data. Data size: " + QString::number(jsonData.size()) + " bytes");
+
+    if (fileSocket->state() != QAbstractSocket::ConnectedState) {
+        logger->log(Logger::DEBUG, "filenetworkmanager.cpp::processSendFileQueue", "Socket is not connected. Cannot send data.");
+        return;
+    }
+
+    if (fileSocket->write(bytes) == -1) {
+        logger->log(Logger::DEBUG, "filenetworkmanager.cpp::processSendFileQueue", "Failed to write data: " + fileSocket->errorString());
+        return;
+    }
+    logger->log(Logger::INFO, "filenetworkmanager.cpp::processSendFileQueue", "Data written to socket. Data size: " + QString::number(bytes.size()) + " bytes");
+}
+
+const std::unordered_map<std::string_view, uint> FileNetworkManager::flagMap = {
+    {"personal_file_url", 1}, {"group_file_url", 2},
+    {"fileData", 3}, {"avatarData", 4},
+    {"avatarUrl", 5}, {"voiceFileData", 6}
+};

--- a/Network/filenetworkmanager.cpp
+++ b/Network/filenetworkmanager.cpp
@@ -12,7 +12,6 @@ FileNetworkManager::FileNetworkManager(QObject *parent)
         logger->log(Logger::INFO,"filenetworkmanager.cpp::constructor","Connection to the FileServer established");
         QJsonObject setIdentifiers;
         setIdentifiers["flag"] = "identifiers";
-        setIdentifiers["userlogin"] = activeUserLogin;
         setIdentifiers["user_id"] = activeUserId;
         sendToFileServer(QJsonDocument(setIdentifiers));
 
@@ -236,8 +235,8 @@ void FileNetworkManager::processSendFileQueue()
     }
 
     QByteArray jsonData = sendFileQueue.head();
-    QByteArray bytes;
-    QDataStream out(&bytes, QIODevice::WriteOnly);
+    writeBuffer.clear();
+    QDataStream out(&writeBuffer, QIODevice::WriteOnly);
     out.setVersion(QDataStream::Qt_6_7);
 
     out << quint32(jsonData.size());
@@ -249,11 +248,11 @@ void FileNetworkManager::processSendFileQueue()
         return;
     }
 
-    if (fileSocket->write(bytes) == -1) {
+    if (fileSocket->write(writeBuffer) == -1) {
         logger->log(Logger::DEBUG, "filenetworkmanager.cpp::processSendFileQueue", "Failed to write data: " + fileSocket->errorString());
         return;
     }
-    logger->log(Logger::INFO, "filenetworkmanager.cpp::processSendFileQueue", "Data written to socket. Data size: " + QString::number(bytes.size()) + " bytes");
+    logger->log(Logger::INFO, "filenetworkmanager.cpp::processSendFileQueue", "Data written to socket. Data size: " + QString::number(writeBuffer.size()) + " bytes");
 }
 
 const std::unordered_map<std::string_view, uint> FileNetworkManager::flagMap = {

--- a/Network/filenetworkmanager.h
+++ b/Network/filenetworkmanager.h
@@ -51,6 +51,7 @@ private slots:
 private:
 
     QTcpSocket* fileSocket;
+    QByteArray writeBuffer;
     QQueue<QByteArray> sendFileQueue;
     QMutex fileMutex;
 

--- a/Network/filenetworkmanager.h
+++ b/Network/filenetworkmanager.h
@@ -1,0 +1,66 @@
+#ifndef FILENETWORKMANAGER_H
+#define FILENETWORKMANAGER_H
+
+#include <QObject>
+#include <QTcpSocket>
+#include <QQueue>
+#include <QFile>
+#include <QFileInfo>
+
+#include <QJsonObject>
+#include <QJsonDocument>
+
+#include <QMutex>
+#include <QTimer>
+
+#include "Utils/logger.h"
+
+class FileNetworkManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FileNetworkManager(QObject *parent = nullptr);
+
+    QAbstractSocket::SocketState getSocketState() const;
+
+public slots:
+    void processSendFileQueue();
+
+    void connectToFileServer();
+    void sendToFileServer(const QJsonDocument &doc);
+    void sendFile(const QString &filePath, const QString &flag);
+    void sendAvatar(const QString &avatarPath, const QString &type, const int& id);
+
+    void setActiveUser(const QString &userName, const int &userId);
+    void setLogger(Logger *logger);
+
+signals:
+    void uploadFiles(const QJsonObject &fileDataJson);
+    void uploadVoiceFile(const QJsonObject &fileDataJson);
+    void uploadAvatar(const QJsonObject &avatarDataJson);
+    void sendAvatarUrl(const QString &avatar_url, const int& user_id, const QString& type);
+
+    void sendMessageWithFile(const QString& fileUrl,const QString &flag);
+
+    void onDisconnected();
+
+private slots:
+    void onFileServerReceived();
+    void handleFileBytesWritten(qint64 bytes);
+
+private:
+
+    QTcpSocket* fileSocket;
+    QQueue<QByteArray> sendFileQueue;
+    QMutex fileMutex;
+
+    QString activeUserLogin;
+    int activeUserId;
+
+    Logger* logger;
+
+    static const std::unordered_map<std::string_view, uint> flagMap;
+    const int MAX_QUEUE_SIZE = 1000;
+};
+
+#endif // FILENETWORKMANAGER_H

--- a/Network/messagenetworkmanager.cpp
+++ b/Network/messagenetworkmanager.cpp
@@ -1,0 +1,240 @@
+#include "messagenetworkmanager.h"
+
+MessageNetworkManager::MessageNetworkManager(QObject *parent)
+    : QObject{parent}
+{
+    socket = new QTcpSocket(this);
+
+    activeUserId = 0;
+    activeUserLogin = "";
+
+    QObject::connect(socket, &QTcpSocket::connected, [this]() {
+        logger->log(Logger::INFO,"messagenetworkmanager.cpp::constructor","Connection to the MessageServer established");
+        emit connectionSuccess();
+
+        if(activeUserId != 0) {
+            QJsonObject setIdentifiers;
+            setIdentifiers["flag"] = "identifiers";
+            setIdentifiers["userlogin"] = activeUserLogin;
+            setIdentifiers["user_id"] = activeUserId;
+            sendData(setIdentifiers);
+        }
+        {
+            QMutexLocker lock(&messageMutex);
+            if (!sendMessageQueue.isEmpty()) {
+                QMetaObject::invokeMethod(this, "processSendMessageQueue", Qt::QueuedConnection);
+            }
+        }
+    });
+
+    connect(socket,&QTcpSocket::readyRead,this,&MessageNetworkManager::onDataReceived);
+    connect(socket,&QTcpSocket::disconnected,this,&MessageNetworkManager::onDisconnected);
+    connect(socket,&QTcpSocket::bytesWritten,this,&MessageNetworkManager::handleMessageBytesWritten);
+    connect(socket, &QAbstractSocket::errorOccurred, [this](QAbstractSocket::SocketError socketError) {
+        emit onDisconnected();
+        logger->log(Logger::ERROR,"messagenetworkmanager.cpp::constructor","Connection to the FileServer error: " + socket->errorString());
+    });
+
+    connectToServer();
+}
+
+QAbstractSocket::SocketState MessageNetworkManager::getSocketState() const
+{
+    return socket->state();
+}
+
+void MessageNetworkManager::connectToServer()
+{
+    QFile file("ip.txt");
+    if (!file.exists() || file.size() == 0) {
+        file.open(QIODevice::WriteOnly | QIODevice::Text);
+        file.write("127.0.0.1\n");
+        file.close();
+    }
+    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    QString ip = QString::fromUtf8(file.readLine()).trimmed();
+    file.close();
+    socket->connectToHost(ip,2020);
+}
+
+void MessageNetworkManager::sendData(const QJsonObject &jsonToSend)
+{
+    QJsonDocument doc(jsonToSend);
+    logger->log(Logger::INFO,"messagenetworkmanager.cpp::sendData","Sending json for " + jsonToSend["flag"].toString());
+    QByteArray jsonDataOut = doc.toJson(QJsonDocument::Compact);
+
+    bool shouldStartProcessing = false;
+    {
+        QMutexLocker lock(&messageMutex);
+        if (sendMessageQueue.size() >= MAX_QUEUE_SIZE) {
+            logger->log(Logger::DEBUG, "messagenetworkmanager.cpp::sendData", "Send queue overflow! Dropping message.");
+            return;
+        }
+        sendMessageQueue.enqueue(jsonDataOut);
+        logger->log(Logger::INFO, "messagenetworkmanager.cpp::sendData", "Message added to queue. Queue size: " + QString::number(sendMessageQueue.size()));
+        shouldStartProcessing = sendMessageQueue.size() == 1;
+    }
+
+    if (shouldStartProcessing) {
+        logger->log(Logger::INFO, "messagenetworkmanager.cpp::sendData", "Starting to process the send queue.");
+        processSendMessageQueue();
+    }
+}
+
+void MessageNetworkManager::setActiveUser(const QString &userName, const int &userId)
+{
+    activeUserId = userId;
+    activeUserLogin = userName;
+}
+
+void MessageNetworkManager::setLogger(Logger *logger)
+{
+    this->logger = logger;
+}
+
+void MessageNetworkManager::onDataReceived()
+{
+    QDataStream in(socket);
+    logger->log(Logger::INFO,"messagenetworkmanager.cpp::onDataReceived","Data packets received");
+    in.setVersion(QDataStream::Qt_6_7);
+
+    static quint32 blockSize = 0;
+
+    if(in.status() != QDataStream::Ok)
+    {
+        logger->log(Logger::WARN,"messagenetworkmanager.cpp::onDataReceived","QDataStream status error");
+        return;
+    }
+
+    while (true) {
+        if (blockSize == 0) {
+            if (socket->bytesAvailable() < sizeof(quint32))
+                return;
+            in >> blockSize;
+        }
+
+        if (socket->bytesAvailable() < blockSize) return;
+
+        QByteArray jsonData;
+        jsonData.resize(blockSize);
+        in.readRawData(jsonData.data(), blockSize);
+
+        QJsonDocument doc = QJsonDocument::fromJson(jsonData);
+
+        if (doc.isNull()) {
+            logger->log(Logger::ERROR,"messagenetworkmanager.cpp::onDataReceived","Received JSON doc is null");
+            blockSize = 0;
+            return;
+        }
+
+        QJsonObject receivedFromServerJson = doc.object();
+
+        QString flag = receivedFromServerJson["flag"].toString();
+        logger->log(Logger::INFO,"messagenetworkmanager.cpp::onDataReceived","Readings JSON for " + flag);
+
+        auto it = flagMap.find(flag.toStdString());
+        uint flagId = (it != flagMap.end()) ? it->second : 0;
+        switch (flagId) {
+        case 1:
+            emit loginResultsReceived(receivedFromServerJson);
+            break;
+        case 2:
+            emit registrationResultsReceived(receivedFromServerJson);
+            break;
+        case 3:
+            emit messageReceived(receivedFromServerJson);
+            break;
+        case 4:
+            emit groupMessageReceived(receivedFromServerJson);
+            break;
+        case 5:
+            emit deleteGroupMemberReceived(receivedFromServerJson);
+            break;
+        case 6:
+            emit addGroupMemberReceived(receivedFromServerJson);
+            break;
+        case 7:
+            if (receivedFromServerJson.contains("dialogs_info") && receivedFromServerJson.contains("groups_info")) {
+                emit dialogsInfoReceived(receivedFromServerJson["dialogs_info"].toObject());
+                emit groupInfoReceived(receivedFromServerJson["groups_info"].toObject());
+            } else {
+                emit removeAccountFromConfigManager();
+                QCoreApplication::quit();
+            }
+            break;
+        case 8:
+            emit searchDataReceived(receivedFromServerJson);
+            break;
+        case 9:
+            emit chatsUpdateDataReceived(receivedFromServerJson);
+            break;
+        case 10:
+            emit loadMeassgesReceived(receivedFromServerJson);
+            break;
+        case 11:
+            emit editResultsReceived(receivedFromServerJson);
+            break;
+        case 12:
+            emit avatarsUpdateReceived(receivedFromServerJson);
+            break;
+        default:
+            logger->log(Logger::WARN, "messagenetworkmanager.cpp::onDataReceived", "Unknown flag received: " + flag);
+            break;
+        }
+        blockSize = 0;
+    }
+    logger->log(Logger::INFO,"messagenetworkmanager.cpp::onDataReceived","Leave onDataReceived");
+}
+
+void MessageNetworkManager::handleMessageBytesWritten(qint64 bytes)
+{
+    QMutexLocker lock(&messageMutex);
+
+    logger->log(Logger::INFO, "messagenetworkmanager.cpp::handleMessageBytesWritten", "Bytes written: " + QString::number(bytes));
+
+    if (!sendMessageQueue.isEmpty()) {
+        sendMessageQueue.dequeue();
+        logger->log(Logger::INFO, "messagenetworkmanager.cpp::handleMessageBytesWritten", "Message dequeued. Queue size: " + QString::number(sendMessageQueue.size()));
+        if (!sendMessageQueue.isEmpty()) {
+            logger->log(Logger::INFO, "messagenetworkmanager.cpp::handleMessageBytesWritten", "More messages in queue. Scheduling next processing.");
+            QTimer::singleShot(10, this, &MessageNetworkManager::processSendMessageQueue);
+        }
+    }
+}
+
+void MessageNetworkManager::processSendMessageQueue()
+{
+    QMutexLocker lock(&messageMutex);
+    if (sendMessageQueue.isEmpty()) {
+        logger->log(Logger::DEBUG, "messagenetworkmanager.cpp::processSendMessageQueue", "Send queue is empty. Nothing to process.");
+        return;
+    }
+
+    QByteArray jsonData = sendMessageQueue.head();
+    QByteArray bytes;
+    QDataStream out(&bytes, QIODevice::WriteOnly);
+    out.setVersion(QDataStream::Qt_6_7);
+
+    out << quint32(jsonData.size());
+    out.writeRawData(jsonData.data(), jsonData.size());
+    logger->log(Logger::INFO, "messagenetworkmanager.cpp::processSendMessageQueue", "Preparing to send data. Data size: " + QString::number(jsonData.size()) + " bytes");
+
+    if (socket->state() != QAbstractSocket::ConnectedState) {
+        logger->log(Logger::DEBUG, "messagenetworkmanager.cpp::processSendMessageQueue", "Socket is not connected. Cannot send data.");
+        return;
+    }
+    if (socket->write(bytes) == -1) {
+        logger->log(Logger::DEBUG, "messagenetworkmanager.cpp::processSendMessageQueue", "Failed to write data: " + socket->errorString());
+        return;
+    }
+    logger->log(Logger::INFO, "messagenetworkmanager.cpp::processSendMessageQueue", "Data written to socket. Data size: " + QString::number(bytes.size()) + " bytes");
+}
+
+const std::unordered_map<std::string_view, uint> MessageNetworkManager::flagMap = {
+    {"login", 1}, {"reg", 2}, {"personal_message", 3},
+    {"group_message", 4}, {"delete_member", 5},
+    {"add_group_members", 6}, {"chats_info", 7},
+    {"search", 8}, {"updating_chats", 9},
+    {"load_messages", 10}, {"edit", 11},
+    {"avatars_update", 12}
+};

--- a/Network/messagenetworkmanager.cpp
+++ b/Network/messagenetworkmanager.cpp
@@ -15,7 +15,6 @@ MessageNetworkManager::MessageNetworkManager(QObject *parent)
         if(activeUserId != 0) {
             QJsonObject setIdentifiers;
             setIdentifiers["flag"] = "identifiers";
-            setIdentifiers["userlogin"] = activeUserLogin;
             setIdentifiers["user_id"] = activeUserId;
             sendData(setIdentifiers);
         }

--- a/Network/messagenetworkmanager.h
+++ b/Network/messagenetworkmanager.h
@@ -1,0 +1,73 @@
+#ifndef MESSAGENETWORKMANAGER_H
+#define MESSAGENETWORKMANAGER_H
+
+#include <QObject>
+#include <QCoreApplication>
+#include <QTcpSocket>
+#include <QQueue>
+
+#include <QJsonObject>
+#include <QJsonDocument>
+
+#include <QMutex>
+#include <QTimer>
+
+#include "Utils/logger.h"
+
+class MessageNetworkManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MessageNetworkManager(QObject *parent = nullptr);
+
+    QAbstractSocket::SocketState getSocketState() const;
+
+public slots:
+    void processSendMessageQueue();
+
+    void connectToServer();
+    void sendData(const QJsonObject &jsonToSend);
+
+    void setActiveUser(const QString &userName, const int &userId);
+    void setLogger(Logger *logger);
+
+signals:
+    void messageReceived(const QJsonObject &receivedMessageJson);
+    void groupMessageReceived(const QJsonObject &receivedMessageJson);
+    void groupInfoReceived(const QJsonObject &receivedGroupInfoJson);
+    void deleteGroupMemberReceived(const QJsonObject &receivedDeleteMemberFromGroup);
+    void addGroupMemberReceived(const QJsonObject &receivedAddMemberFromGroup);
+    void dialogsInfoReceived(const QJsonObject &receivedDialogInfoJson);
+    void loginResultsReceived(const QJsonObject &loginResultsJson);
+    void registrationResultsReceived(const QJsonObject &registrationResultsJson);
+    void searchDataReceived(const QJsonObject &searchDataJson);
+    void chatsUpdateDataReceived(QJsonObject &chatsUpdateDataJson);
+    void loadMeassgesReceived(QJsonObject &messagesJson);
+    void editResultsReceived(const QJsonObject &editResultsJson);
+    void avatarsUpdateReceived(const QJsonObject &avatarsUpdateJson);
+
+    void removeAccountFromConfigManager();
+
+    void connectionSuccess();
+    void onDisconnected();
+
+private slots:
+    void onDataReceived();
+    void handleMessageBytesWritten(qint64 bytes);
+
+private:
+
+    QTcpSocket* socket;
+    QQueue<QByteArray> sendMessageQueue;
+    QMutex messageMutex;
+
+    QString activeUserLogin;
+    int activeUserId;
+
+    Logger* logger;
+
+    static const std::unordered_map<std::string_view, uint> flagMap;
+    const int MAX_QUEUE_SIZE = 1000;
+};
+
+#endif // MESSAGENETWORKMANAGER_H

--- a/Network/networkmanager.cpp
+++ b/Network/networkmanager.cpp
@@ -1,203 +1,36 @@
 #include "networkmanager.h"
 
 NetworkManager::NetworkManager(QObject *parent)
-    : QObject{parent}
-{
-    socket = new QTcpSocket(this);
-    fileSocket = new QTcpSocket(this);
-
-    activeUserId = 0;
-    activeUserLogin = "";
-
-    QObject::connect(socket, &QTcpSocket::connected, [this]() {
-        logger->log(Logger::INFO,"networkmanager.cpp::constructor","Connection to the MessageServer established");
-        emit connectionSuccess();
-
-        if(activeUserId != 0) {
-            QJsonObject setIdentifiers;
-            setIdentifiers["flag"] = "identifiers";
-            setIdentifiers["userlogin"] = activeUserLogin;
-            setIdentifiers["user_id"] = activeUserId;
-            sendData(setIdentifiers);
-        }
-        {
-            QMutexLocker lock(&messageMutex);
-            if (!sendMessageQueue.isEmpty()) {
-                QMetaObject::invokeMethod(this, "processSendMessageQueue", Qt::QueuedConnection);
-            }
-        }
-    });
-    connect(socket,&QTcpSocket::readyRead,this,&NetworkManager::onDataReceived);
-    connect(socket,&QTcpSocket::disconnected,this,&NetworkManager::onDisconnected);
-    connect(socket,&QTcpSocket::bytesWritten,this,&NetworkManager::handleMessageBytesWritten);
-
-    QObject::connect(fileSocket, &QTcpSocket::connected, [this]() {
-        logger->log(Logger::INFO,"networkmanager.cpp::constructor","Connection to the FileServer established");
-        QJsonObject setIdentifiers;
-        setIdentifiers["flag"] = "identifiers";
-        setIdentifiers["userlogin"] = activeUserLogin;
-        setIdentifiers["user_id"] = activeUserId;
-        sendToFileServer(QJsonDocument(setIdentifiers));
-
-        {
-            QMutexLocker lock(&fileMutex);
-            if (!sendFileQueue.isEmpty()) {
-                QMetaObject::invokeMethod(this, "processSendFileQueue", Qt::QueuedConnection);
-            }
-        }
-    });
-    connect(fileSocket,&QTcpSocket::readyRead,this,&NetworkManager::onFileServerReceived);
-    connect(fileSocket,&QTcpSocket::disconnected,this,&NetworkManager::onDisconnected);
-    connect(fileSocket,&QTcpSocket::bytesWritten,this,&NetworkManager::handleFileBytesWritten);
+    : QObject{parent}, fileNetwork(new FileNetworkManager(this)),
+    messageNetwork(new MessageNetworkManager(this)) {
+    connect(fileNetwork, &FileNetworkManager::onDisconnected, this, &NetworkManager::onDisconnected);
+    connect(messageNetwork, &MessageNetworkManager::onDisconnected, this, &NetworkManager::onDisconnected);
+    connect(messageNetwork, &MessageNetworkManager::connectionSuccess, this, &NetworkManager::connectionSuccess);
 
     connect(&reconnectTimer, &QTimer::timeout, this, &NetworkManager::attemptReconnect);
-
-    QObject::connect(socket, &QAbstractSocket::errorOccurred, [this](QAbstractSocket::SocketError socketError) {
-        if (!reconnectTimer.isActive()) {
-            reconnectTimer.start(2000);
-        }
-        logger->log(Logger::ERROR,"networkmanager.cpp::constructor","Connection to the MessageServer error: " + socket->errorString());
-    });
-    QObject::connect(fileSocket, &QAbstractSocket::errorOccurred, [this](QAbstractSocket::SocketError socketError) {
-        if (!reconnectTimer.isActive()) {
-            reconnectTimer.start(2000);
-        }
-        logger->log(Logger::ERROR,"networkmanager.cpp::constructor","Connection to the FileServer error: " + fileSocket->errorString());
-    });
-    connectToServer();
 }
 
-void NetworkManager::connectToServer()
-{
-    QFile file("ip.txt");
-    if (!file.exists() || file.size() == 0) {
-        file.open(QIODevice::WriteOnly | QIODevice::Text);
-        file.write("127.0.0.1\n");
-        file.close();
-    }
-    file.open(QIODevice::ReadOnly | QIODevice::Text);
-    QString ip = QString::fromUtf8(file.readLine()).trimmed();
-    file.close();
-    socket->connectToHost(ip,2020);
+FileNetworkManager *NetworkManager::getFileNetwork() {
+    return this->fileNetwork;
 }
 
-void NetworkManager::connectToFileServer()
-{
-    QFile file("ip.txt");
-    if (!file.exists() || file.size() == 0) {
-        file.open(QIODevice::WriteOnly | QIODevice::Text);
-        file.write("127.0.0.1\n");
-        file.close();
-    }
-    file.open(QIODevice::ReadOnly | QIODevice::Text);
-    QString ip = QString::fromUtf8(file.readLine()).trimmed();
-    file.close();
-    fileSocket->connectToHost(ip,2021);
-}
-
-void NetworkManager::sendData(const QJsonObject &jsonToSend)
-{
-    QJsonDocument doc(jsonToSend);
-    logger->log(Logger::INFO,"networkmanager.cpp::sendData","Sending json for " + jsonToSend["flag"].toString());
-    QByteArray jsonDataOut = doc.toJson(QJsonDocument::Compact);
-
-    bool shouldStartProcessing = false;
-    {
-        QMutexLocker lock(&messageMutex);
-        if (sendMessageQueue.size() >= MAX_QUEUE_SIZE) {
-            logger->log(Logger::DEBUG, "networkmanager.cpp::sendData", "Send queue overflow! Dropping message.");
-            return;
-        }
-        sendMessageQueue.enqueue(jsonDataOut);
-        logger->log(Logger::INFO, "networkmanager.cpp::sendData", "Message added to queue. Queue size: " + QString::number(sendMessageQueue.size()));
-        shouldStartProcessing = sendMessageQueue.size() == 1;
-    }
-
-    if (shouldStartProcessing) {
-        logger->log(Logger::INFO, "networkmanager.cpp::sendData", "Starting to process the send queue.");
-        processSendMessageQueue();
-    }
-}
-
-void NetworkManager::sendToFileServer(const QJsonDocument &doc)
-{
-    logger->log(Logger::INFO,"networkmanager.cpp::sendToFileServer","sendToFileServer starts");
-    QByteArray fileDataOut = doc.toJson(QJsonDocument::Compact);
-
-    bool shouldStartProcessing = false;
-    {
-        QMutexLocker lock(&fileMutex);
-        if (sendFileQueue.size() >= MAX_QUEUE_SIZE) {
-            logger->log(Logger::DEBUG, "networkmanager.cpp::sendToFileServer", "Send queue overflow! Dropping message.");
-            return;
-        }
-        sendFileQueue.enqueue(fileDataOut);
-        logger->log(Logger::INFO, "networkmanager.cpp::sendToFileServer", "Message added to queue. Queue size: " + QString::number(sendFileQueue.size()));
-        shouldStartProcessing = sendFileQueue.size() == 1;
-    }
-
-    if (shouldStartProcessing) {
-        logger->log(Logger::INFO, "networkmanager.cpp::sendToFileServer", "Starting to process the send queue.");
-        processSendFileQueue();
-    }
-}
-
-void NetworkManager::sendFile(const QString &filePath,const QString &flag)
-{
-    logger->log(Logger::INFO,"networkmanager.cpp::sendFile","Sending file");
-    logger->log(Logger::INFO,"networkmanager.cpp::sendFile","filePath = " + filePath);
-    QFile file(filePath);
-    QFileInfo fileInfo(filePath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        logger->log(Logger::WARN,"networkmanager.cpp::sendFile","Failed open file");
-    }
-
-    QByteArray fileData = file.readAll();
-    file.close();
-
-    QJsonObject fileDataJson;
-    fileDataJson["flag"] = flag;
-    fileDataJson["fileName"] = fileInfo.baseName();
-    fileDataJson["fileExtension"] = fileInfo.suffix();
-    fileDataJson["fileData"] = QString(fileData.toBase64());
-
-    QJsonDocument doc(fileDataJson);
-    sendToFileServer(doc);
-}
-
-void NetworkManager::sendAvatar(const QString &avatarPath, const QString &type, const int& id)
-{
-    logger->log(Logger::INFO,"networkmanager.cpp::sendAvatar","Sending avatar");
-    QFile file(avatarPath);
-    QFileInfo fileInfo(avatarPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        logger->log(Logger::WARN,"networkmanager.cpp::sendAvatar","Failed open avatar");
-    }
-
-    QByteArray fileData = file.readAll();
-    file.close();
-
-    QJsonObject fileDataJson;
-    fileDataJson["flag"] = "newAvatarData";
-    fileDataJson["type"] = type;
-    fileDataJson["id"] = id;
-    fileDataJson["fileName"] = fileInfo.baseName();
-    fileDataJson["fileExtension"] = fileInfo.suffix();
-    fileDataJson["fileData"] = QString(fileData.toBase64());
-
-    QJsonDocument doc(fileDataJson);
-    sendToFileServer(doc);
+MessageNetworkManager *NetworkManager::getMessageNetwork() {
+    return this->messageNetwork;
 }
 
 void NetworkManager::setActiveUser(const QString &userName, const int &userId)
 {
     activeUserId = userId;
     activeUserLogin = userName;
+    fileNetwork->setActiveUser(userName,userId);
+    messageNetwork->setActiveUser(userName,userId);
 }
 
 void NetworkManager::setLogger(Logger *logger)
 {
     this->logger = logger;
+    fileNetwork->setLogger(logger);
+    messageNetwork->setLogger(logger);
 }
 
 void NetworkManager::onDisconnected()
@@ -211,242 +44,26 @@ void NetworkManager::onDisconnected()
 void NetworkManager::attemptReconnect()
 {
     emit connectionError();
-    if(socket->state() == QAbstractSocket::UnconnectedState || (activeUserId != 0 ? fileSocket->state() == QAbstractSocket::UnconnectedState : true))
+    if(messageNetwork->getSocketState() == QAbstractSocket::UnconnectedState || (activeUserId != 0 ? fileNetwork->getSocketState() == QAbstractSocket::UnconnectedState : true))
     {
         logger->log(Logger::INFO,"networkmanager.cpp::attemptReconnect","Trying to connect to the server");
         if(activeUserId != 0){
             logger->log(Logger::INFO,"networkmanager.cpp::attemptReconnect","activeUserId != 0");
-            if(socket->state() == QAbstractSocket::UnconnectedState) {
+            if(messageNetwork->getSocketState() == QAbstractSocket::UnconnectedState) {
                 logger->log(Logger::INFO,"networkmanager.cpp::attemptReconnect","socket UnconnectedState");
-                socket->abort();
-                connectToServer();
+                messageNetwork->connectToServer();
             }
-            if(fileSocket->state() == QAbstractSocket::UnconnectedState) {
+            if(fileNetwork->getSocketState() == QAbstractSocket::UnconnectedState) {
                 logger->log(Logger::INFO,"networkmanager.cpp::attemptReconnect","fileSocket UnconnectedState");
-                fileSocket->abort();
-                connectToFileServer();
+                fileNetwork->connectToFileServer();
             }
         } else {
             logger->log(Logger::INFO,"networkmanager.cpp::attemptReconnect","activeUserId == 0");
-            socket->abort();
-            connectToServer();
+            messageNetwork->connectToServer();
         }
-    } else if(socket->state() == QAbstractSocket::ConnectedState && (activeUserId != 0 ? fileSocket->state() == QAbstractSocket::ConnectedState : true)) {
+    } else if(messageNetwork->getSocketState() == QAbstractSocket::ConnectedState && (activeUserId != 0 ? fileNetwork->getSocketState() == QAbstractSocket::ConnectedState : true)) {
         logger->log(Logger::INFO,"networkmanager.cpp::attemptReconnect","Connected");
         emit connectionSuccess();
         reconnectTimer.stop();
     }
-}
-
-void NetworkManager::onDataReceived()
-{
-    QDataStream in(socket);
-    logger->log(Logger::INFO,"networkmanager.cpp::onDataReceived","Data packets received");
-    in.setVersion(QDataStream::Qt_6_7);
-
-    static quint32 blockSize = 0;
-
-    if(in.status() != QDataStream::Ok)
-    {
-        logger->log(Logger::WARN,"networkmanager.cpp::onDataReceived","QDataStream status error");
-        return;
-    }
-
-    while (true) {
-        if (blockSize == 0) {
-            if (socket->bytesAvailable() < sizeof(quint32))
-                return;
-            in >> blockSize;
-        }
-
-        if (socket->bytesAvailable() < blockSize) return;
-
-        QByteArray jsonData;
-        jsonData.resize(blockSize);
-        in.readRawData(jsonData.data(), blockSize);
-
-        QJsonDocument doc = QJsonDocument::fromJson(jsonData);
-
-        if (doc.isNull()) {
-            logger->log(Logger::ERROR,"networkmanager.cpp::onDataReceived","Received JSON doc is null");
-            blockSize = 0;
-            return;
-        }
-
-        QJsonObject receivedFromServerJson = doc.object();
-
-        QString flag = receivedFromServerJson["flag"].toString();
-        logger->log(Logger::INFO,"networkmanager.cpp::onDataReceived","Readings JSON for " + flag);
-
-        if(flag == "login") emit loginResultsReceived(receivedFromServerJson);
-        else if(flag == "reg") emit registrationResultsReceived(receivedFromServerJson);
-        else if(flag == "personal_message") emit messageReceived(receivedFromServerJson);
-        else if(flag == "group_message") emit groupMessageReceived(receivedFromServerJson);
-        else if(flag == "delete_member") emit deleteGroupMemberReceived(receivedFromServerJson);
-        else if(flag == "add_group_members") emit addGroupMemberReceived(receivedFromServerJson);
-        else if(flag == "chats_info") {
-            if(receivedFromServerJson.contains("dialogs_info") && receivedFromServerJson.contains("groups_info")){
-                emit dialogsInfoReceived(receivedFromServerJson["dialogs_info"].toObject());
-                emit groupInfoReceived(receivedFromServerJson["groups_info"].toObject());
-            } else {
-                emit removeAccountFromConfigManager();
-                QCoreApplication::quit();
-            }
-        }
-        else if(flag == "search")  emit searchDataReceived(receivedFromServerJson);
-        else if(flag == "updating_chats") emit chatsUpdateDataReceived(receivedFromServerJson);
-        else if(flag == "load_messages") emit loadMeassgesReceived(receivedFromServerJson);
-        else if(flag == "edit") emit editResultsReceived(receivedFromServerJson);
-        else if(flag == "avatars_update") emit avatarsUpdateReceived(receivedFromServerJson);
-        else if(flag == "avatarUrl") emit sendAvatarUrl(receivedFromServerJson["avatar_url"].toString(),receivedFromServerJson["id"].toInt(),receivedFromServerJson["type"].toString());
-
-        blockSize = 0;
-    }
-    logger->log(Logger::INFO,"networkmanager.cpp::onDataReceived","Leave onDataReceived");
-
-}
-
-void NetworkManager::onFileServerReceived()
-{
-    QDataStream in(fileSocket);
-    logger->log(Logger::INFO,"networkmanager.cpp::onFileServerReceived","Data from FileServer received");
-    in.setVersion(QDataStream::Qt_6_7);
-
-    static quint32 blockSize = 0;
-
-    if(in.status() == QDataStream::Ok) {
-        logger->log(Logger::ERROR, "networkmanager.cpp::onFileServerReceived", "Error reading data from socket: " + QString::number(in.status()));
-        return;
-    }
-
-    while (true) {
-        if (blockSize == 0) {
-            if (fileSocket->bytesAvailable() < sizeof(quint32))
-                return;
-            in >> blockSize;
-        }
-
-        if (fileSocket->bytesAvailable() < blockSize)
-            return;
-
-        QByteArray jsonData;
-        jsonData.resize(blockSize);
-        in.readRawData(jsonData.data(), blockSize);
-
-        QJsonDocument doc = QJsonDocument::fromJson(jsonData);
-
-        if (doc.isNull()) {
-            logger->log(Logger::ERROR,"networkmanager.cpp::onFileServerReceived","Received JSON doc is null");
-            blockSize = 0;
-            return;
-        }
-
-        QJsonObject receivedFromServerJson = doc.object();
-        if(receivedFromServerJson["flag"].toString() == "personal_file_url") {
-            QString fileUrl = receivedFromServerJson["fileUrl"].toString();
-            emit sendMessageWithFile(fileUrl,"personal");
-        } else if(receivedFromServerJson["flag"].toString() == "group_file_url") {
-            QString fileUrl = receivedFromServerJson["fileUrl"].toString();
-            emit sendMessageWithFile(fileUrl,"group");
-        } else if (receivedFromServerJson["flag"].toString() == "fileData") {
-            emit uploadFiles(receivedFromServerJson);
-        } else if (receivedFromServerJson["flag"].toString() == "avatarData") {
-            emit uploadAvatar(receivedFromServerJson);
-        } else if (receivedFromServerJson["flag"].toString() == "avatarUrl") {
-            emit sendAvatarUrl(receivedFromServerJson["avatar_url"].toString(),receivedFromServerJson["id"].toInt(),receivedFromServerJson["type"].toString());
-        } else if (receivedFromServerJson["flag"].toString() == "voiceFileData") {
-            emit uploadVoiceFile(receivedFromServerJson);
-        }
-
-        blockSize = 0;
-    }
-}
-
-void NetworkManager::handleMessageBytesWritten(qint64 bytes)
-{
-    QMutexLocker lock(&messageMutex);
-
-    logger->log(Logger::INFO, "networkmanager.cpp::handleMessageBytesWritten", "Bytes written: " + QString::number(bytes));
-
-    if (!sendMessageQueue.isEmpty()) {
-        sendMessageQueue.dequeue();
-        logger->log(Logger::INFO, "networkmanager.cpp::handleMessageBytesWritten", "Message dequeued. Queue size: " + QString::number(sendMessageQueue.size()));
-        if (!sendMessageQueue.isEmpty()) {
-            logger->log(Logger::INFO, "networkmanager.cpp::handleMessageBytesWritten", "More messages in queue. Scheduling next processing.");
-            QTimer::singleShot(10, this, &NetworkManager::processSendMessageQueue);
-        }
-    }
-}
-
-void NetworkManager::handleFileBytesWritten(qint64 bytes)
-{
-    QMutexLocker lock(&fileMutex);
-
-    logger->log(Logger::INFO, "networkmanager.cpp::handleFileBytesWritten", "Bytes written: " + QString::number(bytes));
-
-    if (!sendFileQueue.isEmpty()) {
-        sendFileQueue.dequeue();
-        logger->log(Logger::INFO, "networkmanager.cpp::handleFileBytesWritten", "Message dequeued. Queue size: " + QString::number(sendFileQueue.size()));
-        if (!sendFileQueue.isEmpty()) {
-            logger->log(Logger::INFO, "networkmanager.cpp::handleFileBytesWritten", "More messages in queue. Scheduling next processing.");
-            QTimer::singleShot(10, this, &NetworkManager::processSendFileQueue);
-        }
-    }
-}
-
-void NetworkManager::processSendFileQueue()
-{
-    QMutexLocker lock(&fileMutex);
-    if (sendFileQueue.isEmpty()) {
-        logger->log(Logger::DEBUG, "networkmanager.cpp::processSendFileQueue", "Send file queue is empty. Nothing to process.");
-        return;
-    }
-
-    QByteArray jsonData = sendFileQueue.head();
-    QByteArray bytes;
-    QDataStream out(&bytes, QIODevice::WriteOnly);
-    out.setVersion(QDataStream::Qt_6_7);
-
-    out << quint32(jsonData.size());
-    out.writeRawData(jsonData.data(), jsonData.size());
-    logger->log(Logger::INFO, "networkmanager.cpp::processSendFileQueue", "Preparing to send data. Data size: " + QString::number(jsonData.size()) + " bytes");
-
-    if (fileSocket->state() != QAbstractSocket::ConnectedState) {
-        logger->log(Logger::DEBUG, "networkmanager.cpp::processSendFileQueue", "Socket is not connected. Cannot send data.");
-        return;
-    }
-
-    if (fileSocket->write(bytes) == -1) {
-        logger->log(Logger::DEBUG, "networkmanager.cpp::processSendFileQueue", "Failed to write data: " + fileSocket->errorString());
-        return;
-    }
-    logger->log(Logger::INFO, "networkmanager.cpp::processSendFileQueue", "Data written to socket. Data size: " + QString::number(bytes.size()) + " bytes");
-}
-
-void NetworkManager::processSendMessageQueue()
-{
-    QMutexLocker lock(&messageMutex);
-    if (sendMessageQueue.isEmpty()) {
-        logger->log(Logger::DEBUG, "networkmanager.cpp::processSendMessageQueue", "Send queue is empty. Nothing to process.");
-        return;
-    }
-
-    QByteArray jsonData = sendMessageQueue.head();
-    QByteArray bytes;
-    QDataStream out(&bytes, QIODevice::WriteOnly);
-    out.setVersion(QDataStream::Qt_6_7);
-
-    out << quint32(jsonData.size());
-    out.writeRawData(jsonData.data(), jsonData.size());
-    logger->log(Logger::INFO, "networkmanager.cpp::processSendMessageQueue", "Preparing to send data. Data size: " + QString::number(jsonData.size()) + " bytes");
-
-    if (socket->state() != QAbstractSocket::ConnectedState) {
-        logger->log(Logger::DEBUG, "networkmanager.cpp::processSendMessageQueue", "Socket is not connected. Cannot send data.");
-        return;
-    }
-    if (socket->write(bytes) == -1) {
-        logger->log(Logger::DEBUG, "networkmanager.cpp::processSendMessageQueue", "Failed to write data: " + socket->errorString());
-        return;
-    }
-    logger->log(Logger::INFO, "networkmanager.cpp::processSendMessageQueue", "Data written to socket. Data size: " + QString::number(bytes.size()) + " bytes");
 }

--- a/Network/networkmanager.h
+++ b/Network/networkmanager.h
@@ -26,6 +26,8 @@ public:
     void connectToServer();
 
 public slots:
+    void connectToFileServer(QString &userlogin,int &user_id);
+
     void sendData(const QJsonObject &jsonToSend);
     void sendToFileServer(const QJsonDocument &doc);
     void sendFile(const QString &filePath,const QString &flag);
@@ -70,6 +72,8 @@ private slots:
     void onFileServerReceived();
 
 private:
+    void connectToServer(const QString &userlogin,const int &user_id);
+
     QString activeUserLogin;
     int activeUserId;
 

--- a/Network/networkmanager.h
+++ b/Network/networkmanager.h
@@ -18,6 +18,9 @@
 
 #include <QTimer>
 
+#include "messagenetworkmanager.h"
+#include "filenetworkmanager.h"
+
 #include "Utils/logger.h"
 
 class NetworkManager : public QObject
@@ -26,76 +29,30 @@ class NetworkManager : public QObject
 public:
     explicit NetworkManager(QObject *parent = nullptr);
 
-    void connectToServer();
+    FileNetworkManager *getFileNetwork();
+    MessageNetworkManager *getMessageNetwork();
 
 public slots:
-    void connectToFileServer();
-
-    void sendData(const QJsonObject &jsonToSend);
-    void sendToFileServer(const QJsonDocument &doc);
-    void sendFile(const QString &filePath,const QString &flag);
-    void sendAvatar(const QString &avatarPath, const QString &type, const int& id);
-
-    void processSendFileQueue();
-    void processSendMessageQueue();
-
     void setActiveUser(const QString &userName,const int &userId);
     void setLogger(Logger *logger);
+
 signals:
-    void dataReceived(const QJsonDocument &doc);
-    void uploadFiles(const QJsonObject &fileDataJson);
-    void uploadVoiceFile(const QJsonObject &fileDataJson);
-    void uploadAvatar(const QJsonObject &avatarDataJson);
-    void sendAvatarUrl(const QString &avatar_url,const int& user_id, const QString& type);
-
-    void messageReceived(const QJsonObject &receivedMessageJson);
-    void groupMessageReceived(const QJsonObject &receivedMessageJson);
-    void groupInfoReceived(const QJsonObject &receivedGroupInfoJson);
-    void deleteGroupMemberReceived(const QJsonObject &receivedDeleteMemberFromGroup);
-    void addGroupMemberReceived(const QJsonObject &receivedAddMemberFromGroup);
-    void dialogsInfoReceived(const QJsonObject &receivedDialogInfoJson);
-    void loginResultsReceived(const QJsonObject &loginResultsJson);
-    void registrationResultsReceived(const QJsonObject &registrationResultsJson);
-    void searchDataReceived(const QJsonObject &searchDataJson);
-    void chatsUpdateDataReceived(QJsonObject &chatsUpdateDataJson);
-    void loadMeassgesReceived(QJsonObject &messagesJson);
-    void editResultsReceived(const QJsonObject &editResultsJson);
-    void avatarsUpdateReceived(const QJsonObject &avatarsUpdateJson);
-
-    void sendMessageWithFile(const QString& fileUrl,const QString &flag);
-
     void connectionError();
     void connectionSuccess();
-
-    void removeAccountFromConfigManager();
-
 
 private slots:
     void onDisconnected();
     void attemptReconnect();
 
-    void onDataReceived();
-    void onFileServerReceived();
-
-    void handleMessageBytesWritten(qint64 bytes);
-    void handleFileBytesWritten(qint64 bytes);
-
 private:
-
-    QQueue<QByteArray> sendFileQueue;
-    QQueue<QByteArray> sendMessageQueue;
-    QMutex fileMutex;
-    QMutex messageMutex;
+    FileNetworkManager *fileNetwork;
+    MessageNetworkManager *messageNetwork;
 
     QString activeUserLogin;
     int activeUserId;
 
-    QTcpSocket* fileSocket;
-    QTcpSocket* socket;
     QTimer reconnectTimer;
     Logger* logger;
-
-    const int MAX_QUEUE_SIZE = 1000;
 };
 
 #endif // NETWORKMANAGER_H

--- a/Network/networkmanager.h
+++ b/Network/networkmanager.h
@@ -26,7 +26,7 @@ public:
     void connectToServer();
 
 public slots:
-    void connectToFileServer(QString &userlogin,int &user_id);
+    void connectToFileServer();
 
     void sendData(const QJsonObject &jsonToSend);
     void sendToFileServer(const QJsonDocument &doc);
@@ -72,8 +72,6 @@ private slots:
     void onFileServerReceived();
 
 private:
-    void connectToServer(const QString &userlogin,const int &user_id);
-
     QString activeUserLogin;
     int activeUserId;
 

--- a/Network/networkmanager.h
+++ b/Network/networkmanager.h
@@ -12,6 +12,9 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QQueue>
+
+#include <QMutex>
 
 #include <QTimer>
 
@@ -32,6 +35,9 @@ public slots:
     void sendToFileServer(const QJsonDocument &doc);
     void sendFile(const QString &filePath,const QString &flag);
     void sendAvatar(const QString &avatarPath, const QString &type, const int& id);
+
+    void processSendFileQueue();
+    void processSendMessageQueue();
 
     void setActiveUser(const QString &userName,const int &userId);
     void setLogger(Logger *logger);
@@ -71,7 +77,16 @@ private slots:
     void onDataReceived();
     void onFileServerReceived();
 
+    void handleMessageBytesWritten(qint64 bytes);
+    void handleFileBytesWritten(qint64 bytes);
+
 private:
+
+    QQueue<QByteArray> sendFileQueue;
+    QQueue<QByteArray> sendMessageQueue;
+    QMutex fileMutex;
+    QMutex messageMutex;
+
     QString activeUserLogin;
     int activeUserId;
 
@@ -79,6 +94,8 @@ private:
     QTcpSocket* socket;
     QTimer reconnectTimer;
     Logger* logger;
+
+    const int MAX_QUEUE_SIZE = 1000;
 };
 
 #endif // NETWORKMANAGER_H

--- a/main.cpp
+++ b/main.cpp
@@ -56,11 +56,6 @@ int main(int argc, char *argv[])
         if (rootObjects.isEmpty()) {
             engine.load(switchUrl);
         }
-        /*if (!rootObjects.isEmpty()) {
-            QObject *rootObject = rootObjects.first();
-            rootObject->deleteLater();
-        }
-        engine.load(switchUrl);*/
     });
     QObject::connect(&client, &Client::connectionError, [&engine, switchUrl]() {
         QList<QObject*> rootObjects = engine.rootObjects();

--- a/main.cpp
+++ b/main.cpp
@@ -53,11 +53,14 @@ int main(int argc, char *argv[])
 
     QObject::connect(&client, &Client::connectionSuccess, [&engine, switchUrl]() {
         QList<QObject*> rootObjects = engine.rootObjects();
-        if (!rootObjects.isEmpty()) {
+        if (rootObjects.isEmpty()) {
+            engine.load(switchUrl);
+        }
+        /*if (!rootObjects.isEmpty()) {
             QObject *rootObject = rootObjects.first();
             rootObject->deleteLater();
         }
-        engine.load(switchUrl);
+        engine.load(switchUrl);*/
     });
     QObject::connect(&client, &Client::connectionError, [&engine, switchUrl]() {
         QList<QObject*> rootObjects = engine.rootObjects();

--- a/qmlFiles/MessageLine.qml
+++ b/qmlFiles/MessageLine.qml
@@ -243,19 +243,19 @@ Rectangle{
             if (edtText.text.trim() !== "") {
                 if (upLine.currentState == "personal") {
                     if(fileLoad) {
-                        client.sendMessageWithFile(edtText.text.trim(), nameText.text,upLine.user_id,filePath,"personal")
+                        client.sendMessageWithFile(edtText.text.trim(), upLine.user_id, filePath, "personal")
                         fileLoad = false;
                         filePath = "";
                     } else {
-                        client.sendMessage(edtText.text.trim(), nameText.text,upLine.user_id,"personal");
+                        client.sendMessage(edtText.text.trim(), upLine.user_id, "personal");
                     }
                 } else if (upLine.currentState == "group") {
                     if(fileLoad) {
-                        client.sendMessageWithFile(edtText.text.trim(), nameText.text,upLine.user_id,filePath,"group")
+                        client.sendMessageWithFile(edtText.text.trim(), upLine.user_id, filePath, "group")
                         fileLoad = false;
                         filePath = "";
                     } else {
-                        client.sendMessage(edtText.text.trim(), nameText.text,upLine.user_id,"group");
+                        client.sendMessage(edtText.text.trim(), upLine.user_id, "group");
                     }
                 }
                 edtText.clear();


### PR DESCRIPTION
- **The responsibility** of the `NetworkManager` class **has been divided** into classes: 
1. `MessageNetworkManager` for handling the **message socket**;
2. `FileNetworkManager` for handling the **file socket**.
- **The structure of the message** for sending a request for avatar updates to the server **has been changed**.
- **Sending identifiers** now **occurs immediately** after processing a successful login, instead of them **being provided** to the server directly **during login**.
- **The logic** for sending messages to servers **has been changed**.
- `NetworkManager` is now **a coordinator class** between the `MessageNetworkManager` and `FileNetworkManager` classes.
- **The logic** for trying to reconnect **has been improved**.